### PR TITLE
按住说话组件

### DIFF
--- a/health-app/app.js
+++ b/health-app/app.js
@@ -1,0 +1,12 @@
+// app.js
+App({
+  onLaunch() {
+    // 展示本地存储能力
+    const logs = wx.getStorageSync('logs') || []
+    logs.unshift(Date.now())
+    wx.setStorageSync('logs', logs)
+  },
+  globalData: {
+    userInfo: null
+  }
+})

--- a/health-app/app.json
+++ b/health-app/app.json
@@ -1,0 +1,16 @@
+{
+  "pages": [
+    "pages/index/index"
+  ],
+  "window": {
+    "backgroundTextStyle": "light",
+    "navigationBarBackgroundColor": "#fff",
+    "navigationBarTitleText": "健康助手",
+    "navigationBarTextStyle": "black",
+    "navigationStyle": "custom"
+  },
+  "usingComponents": {
+    "speak-button": "/components/speak-button/index"
+  },
+  "sitemapLocation": "sitemap.json"
+}

--- a/health-app/app.wxss
+++ b/health-app/app.wxss
@@ -1,0 +1,14 @@
+/** app.wxss **/
+.container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+} 
+
+page {
+  background-color: #f5f7fa;
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Segoe UI, Arial, Roboto, 'PingFang SC', 'miui', 'Hiragino Sans GB', 'Microsoft Yahei', sans-serif;
+}

--- a/health-app/components/speak-button/index.js
+++ b/health-app/components/speak-button/index.js
@@ -1,0 +1,29 @@
+Component({
+  properties: {
+    // 这里可以定义传入的属性
+  },
+
+  data: {
+    // 组件内部数据
+  },
+
+  methods: {
+    onSpeakBtnPress() {
+      wx.showToast({
+        title: '开始录音...',
+        icon: 'none'
+      });
+      // 触发父组件事件，以便父组件也可以处理逻辑
+      this.triggerEvent('startrecord');
+    },
+    
+    onSpeakBtnRelease() {
+      wx.showToast({
+        title: '录音结束',
+        icon: 'success'
+      });
+      // 触发父组件事件
+      this.triggerEvent('stoprecord');
+    }
+  }
+})

--- a/health-app/components/speak-button/index.json
+++ b/health-app/components/speak-button/index.json
@@ -1,0 +1,3 @@
+{
+  "component": true
+}

--- a/health-app/components/speak-button/index.wxml
+++ b/health-app/components/speak-button/index.wxml
@@ -1,0 +1,3 @@
+<button class="speak-btn" hover-class="speak-btn-hover" bindtouchstart="onSpeakBtnPress" bindtouchend="onSpeakBtnRelease">
+  按住说话
+</button>

--- a/health-app/components/speak-button/index.wxss
+++ b/health-app/components/speak-button/index.wxss
@@ -1,0 +1,20 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.speak-btn {
+  background-color: #007aff;
+  color: #fff;
+  border-radius: 50rpx;
+  font-size: 34rpx;
+  font-weight: 600;
+  padding: 25rpx 0;
+  width: 100%;
+  box-shadow: 0 10rpx 30rpx rgba(0, 122, 255, 0.3);
+}
+
+.speak-btn-hover {
+  background-color: #0062cc;
+  transform: scale(0.98);
+}

--- a/health-app/pages/index/index.js
+++ b/health-app/pages/index/index.js
@@ -1,0 +1,38 @@
+// pages/index/index.js
+Page({
+  data: {
+    // 顶部状态栏高度适配（假设值，实际开发中需获取系统信息）
+    statusBarHeight: 44, 
+    navBarHeight: 44,
+    
+    menuItems: [
+      { id: 1, title: '健康日历', icon: '📅', color: '#e3f2fd', iconColor: '#2196f3' },
+      { id: 2, title: '健康咨询', icon: '💓', color: '#e3f2fd', iconColor: '#2196f3' },
+      { id: 3, title: '望诊', icon: '👅', color: '#e3f2fd', iconColor: '#2196f3' },
+      { id: 4, title: '认知训练', icon: '🧠', color: '#e3f2fd', iconColor: '#2196f3' },
+      { id: 5, title: '拍照识成分', icon: '📷', color: '#e3f2fd', iconColor: '#2196f3' },
+      { id: 6, title: '拍照识营养', icon: '🥗', color: '#e3f2fd', iconColor: '#2196f3' },
+      { id: 7, title: '健康档案', icon: '📂', color: '#e3f2fd', iconColor: '#2196f3' }
+    ],
+    
+    hotTopic: '甲流过后新冠又开始了吗？',
+    tip: '今天教你如何正确晒背'
+  },
+
+  onLoad() {
+    // 获取系统信息以适配刘海屏等
+    const systemInfo = wx.getSystemInfoSync();
+    this.setData({
+      statusBarHeight: systemInfo.statusBarHeight
+    });
+  },
+
+  onMenuItemTap(e) {
+    const item = e.currentTarget.dataset.item;
+    wx.showToast({
+      title: `点击了${item.title}`,
+      icon: 'none'
+    });
+  },
+
+})

--- a/health-app/pages/index/index.wxml
+++ b/health-app/pages/index/index.wxml
@@ -1,0 +1,51 @@
+<view class="page-container">
+  <!-- 顶部背景 -->
+  <view class="bg-gradient"></view>
+
+  <!-- 自定义导航栏占位 -->
+  <view style="height: {{statusBarHeight}}px;"></view>
+  
+  <view class="content-wrapper">
+    <!-- 头部区域 -->
+    <view class="header">
+      <view class="header-top">
+        <text class="main-title">您的健康我来守护</text>
+        <view class="user-icon">
+           <!-- 简单的 Grid 图标样式 -->
+           <view class="grid-icon-dots">
+             <view class="dot"></view><view class="dot"></view>
+             <view class="dot"></view><view class="dot"></view>
+           </view>
+        </view>
+      </view>
+      <text class="sub-title">24小时在线为您解答健康问题</text>
+    </view>
+
+    <!-- 功能宫格区域 -->
+    <view class="grid-container">
+      <block wx:for="{{menuItems}}" wx:key="id">
+        <view class="grid-item" bindtap="onMenuItemTap" data-item="{{item}}">
+          <view class="icon-circle">
+            <text class="emoji">{{item.icon}}</text>
+          </view>
+          <text class="item-title">{{item.title}}</text>
+        </view>
+      </block>
+    </view>
+
+    <!-- 底部区域 (Flex 自动撑开或绝对定位) -->
+    <view class="bottom-area">
+      <view class="bubble-container">
+        <view class="bubble hot-bubble">
+          <text>{{hotTopic}}</text>
+          <view class="hot-badge">热</view>
+        </view>
+        <view class="bubble tip-bubble">
+          <text>{{tip}}</text>
+        </view>
+      </view>
+
+      <speak-button></speak-button>
+    </view>
+  </view>
+</view>

--- a/health-app/pages/index/index.wxss
+++ b/health-app/pages/index/index.wxss
@@ -1,0 +1,160 @@
+/* pages/index/index.wxss */
+.page-container {
+  min-height: 100vh;
+  position: relative;
+  overflow-y: hidden; /* 防止背景滚动 */
+}
+
+.bg-gradient {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100vh;
+  background: linear-gradient(180deg, #eaf5fe 0%, #f5f7fa 40%, #eaf5fe 100%);
+  z-index: -1;
+}
+
+.content-wrapper {
+  padding: 20rpx 30rpx;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 88px); /* 减去头部预估高度 */
+}
+
+/* Header */
+.header {
+  margin-top: 20rpx;
+  margin-bottom: 40rpx;
+}
+
+.header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10rpx;
+}
+
+.main-title {
+  font-size: 44rpx;
+  font-weight: 800;
+  color: #000;
+}
+
+.sub-title {
+  font-size: 26rpx;
+  color: #999;
+}
+
+.user-icon {
+  width: 60rpx;
+  height: 60rpx;
+  background-color: #2196f3;
+  border-radius: 16rpx;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4rpx 10rpx rgba(33, 150, 243, 0.3);
+}
+
+.grid-icon-dots {
+  display: flex;
+  flex-wrap: wrap;
+  width: 24rpx;
+  height: 24rpx;
+  justify-content: space-between;
+}
+
+.dot {
+  width: 10rpx;
+  height: 10rpx;
+  background-color: #fff;
+  border-radius: 2rpx;
+  margin-bottom: 2rpx;
+}
+
+/* Grid System */
+.grid-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding-bottom: 40rpx;
+}
+
+.grid-item {
+  width: 48%;
+  background-color: #fff;
+  border-radius: 30rpx;
+  padding: 40rpx 0;
+  margin-bottom: 30rpx;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10rpx 30rpx rgba(220, 230, 245, 0.6);
+  position: relative;
+}
+
+/* Icon Styling */
+.icon-circle {
+  width: 80rpx;
+  height: 80rpx;
+  border-radius: 50% 50% 50% 0; /* Teardrop shape ish */
+  background-color: #e3f2fd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20rpx;
+  transform: rotate(-45deg); /* Rotate to make it look like a drop */
+}
+
+.emoji {
+  font-size: 40rpx;
+  transform: rotate(45deg); /* Counter rotate content */
+}
+
+.item-title {
+  font-size: 32rpx;
+  font-weight: 600;
+  color: #333;
+}
+
+/* Bottom Area */
+.bottom-area {
+  margin-top: auto;
+  padding-bottom: 60rpx;
+}
+
+.bubble-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 40rpx;
+}
+
+.bubble {
+  background-color: #fff;
+  padding: 20rpx 30rpx;
+  border-radius: 30rpx 30rpx 30rpx 4rpx;
+  box-shadow: 0 4rpx 20rpx rgba(0,0,0,0.05);
+  margin-bottom: 20rpx;
+  font-size: 28rpx;
+  color: #333;
+  display: flex;
+  align-items: center;
+  max-width: 80%;
+}
+
+.hot-bubble {
+  background-color: #f0f7ff;
+}
+
+.hot-badge {
+  background-color: #ff5252;
+  color: #fff;
+  font-size: 20rpx;
+  padding: 2rpx 8rpx;
+  border-radius: 8rpx;
+  margin-left: 10rpx;
+}
+


### PR DESCRIPTION
Extract 'hold to speak' functionality into a reusable `speak-button` component for global use across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-d114a7c3-0dd9-4404-87c8-06efe4ed8e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d114a7c3-0dd9-4404-87c8-06efe4ed8e3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a WeChat Mini Program scaffold with a new home page and a reusable voice input button.
> 
> - Adds `components/speak-button` with press/release handlers, toast feedback, and `startrecord`/`stoprecord` events
> - Registers `speak-button` in `app.json` and integrates it into the index page’s bottom area
> - Implements `pages/index` with header, feature grid, hot-topic/tip bubbles, and basic tap toasts; adapts to `statusBarHeight`
> - Adds base app files (`app.js`, `app.json`, `app.wxss`) and global styling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 244acf0b8776d5cb9ed340d0b653162e735346a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->